### PR TITLE
SQL Injection

### DIFF
--- a/java/UserServlet.java
+++ b/java/UserServlet.java
@@ -18,11 +18,12 @@ public class UserServlet extends HttpServlet {
 
         try {
             Connection conn = DriverManager.getConnection("jdbc:mysql://localhost:3306/mydatabase", "user", "password");
-            Statement stmt = conn.createStatement();
-
-            // Vulnerability: Concatenation of user input in SQL query
-            String query = "SELECT * FROM users WHERE id = " + userId;
-            ResultSet rs = stmt.executeQuery(query);
+            
+            // Use PreparedStatement to prevent SQL Injection
+            String query = "SELECT * FROM users WHERE id = ?";
+            PreparedStatement pstmt = conn.prepareStatement(query);
+            pstmt.setString(1, userId);
+            ResultSet rs = pstmt.executeQuery();
 
             while (rs.next()) {
                 out.println("User ID: " + rs.getInt("id"));
@@ -30,7 +31,7 @@ public class UserServlet extends HttpServlet {
             }
 
             rs.close();
-            stmt.close();
+            pstmt.close();
             conn.close();
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
The code was fixed by replacing the vulnerable SQL query construction with a parameterized query using a `PreparedStatement`. Instead of concatenating the `userId` directly into the SQL query string, which exposed the application to SQL Injection attacks, the code now uses a placeholder (`?`) in the query string. The `PreparedStatement` object is then used to safely set the `userId` parameter with `pstmt.setString(1, userId);`. This approach ensures that the user input is treated as a parameter rather than executable SQL code, effectively mitigating the risk of SQL Injection.

**Additional Tips:**
1. Always use parameterized queries or stored procedures when interacting with databases to prevent SQL Injection.
2. Validate and sanitize user inputs as an additional layer of security.
3. Regularly review and test your code for vulnerabilities, especially when dealing with user inputs and database operations.

Created by: plexicus@plexicus.com