### PR TITLE
OS Command Injection

### DIFF
--- a/typescript/vulnerableCommandExecution.ts
+++ b/typescript/vulnerableCommandExecution.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import express from 'express';
 
 const app = express();
@@ -8,8 +8,14 @@ app.use(express.json());
 app.post('/run-command', (req, res) => {
     const userCommand = req.body.command;  // User input from the request body
 
-    // Vulnerability: Directly using user input in a command executed by the system
-    exec(userCommand, (error, stdout, stderr) => {
+    // Validate and sanitize user input
+    const allowedCommands = ['ls', 'pwd', 'whoami'];
+    if (!allowedCommands.includes(userCommand)) {
+        res.status(400).send('Invalid command');
+        return;
+    }
+
+    execFile(userCommand, (error, stdout, stderr) => {
         if (error) {
             res.status(500).send(`Error executing command: ${error.message}`);
             return;


### PR DESCRIPTION
The code was fixed by replacing the use of `exec` with `execFile`, which is a safer alternative for executing system commands. Unlike `exec`, `execFile` does not spawn a shell, which reduces the risk of shell injection vulnerabilities. This change alone significantly mitigates the risk of command injection.

Additionally, the code now includes a validation step where the user input is checked against a predefined list of allowed commands (`allowedCommands`). This ensures that only specific, safe commands can be executed, preventing arbitrary command execution. If the user input does not match any of the allowed commands, the server responds with a 400 status code and an "Invalid command" message, effectively blocking unauthorized command execution.

These changes address the vulnerability by both limiting the commands that can be executed and using a safer method for command execution, thus reducing the risk of arbitrary command injection and potential system compromise.

Created by: plexicus@plexicus.com